### PR TITLE
Fix frame-based OCR checkbox logic

### DIFF
--- a/src/static/script.js
+++ b/src/static/script.js
@@ -306,9 +306,15 @@ intervalInput.addEventListener("input", (event) => {
 
 const frameBasedOCRCheckbox = document.getElementById('frameBasedOCR');
 frameBasedOCRCheckbox.addEventListener('change', function() {
-    // 체크박스가 선택되면 숫자 입력 필드를 비활성화, 아니면 활성화합니다.
-    intervalInput.disabled = this.checked;
-    intervalValue = -1;
+    if (this.checked) {
+        // 체크되면 입력 필드를 비활성화하고 intervalValue를 -1로 설정
+        intervalInput.disabled = true;
+        intervalValue = -1;
+    } else {
+        // 체크 해제 시 입력 필드 활성화 후 현재 값을 intervalValue로 사용
+        intervalInput.disabled = false;
+        intervalValue = parseFloat(intervalInput.value);
+    }
 });
 
 // mm:ss 형식의 문자열을 초 단위로 변환하는 함수 (예: "02:30" -> 150초)


### PR DESCRIPTION
## Summary
- update `frameBasedOCR` checkbox change handler to correctly toggle interval value and input disabled state

## Testing
- `pip install ollama==0.1.6`
- `pip install thefuzz`
- `PYTHONPATH=$PWD pytest -q` *(fails: fixture 'csv_filename' not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f86e54c94832a8ee87aa8e86151a2