### PR TITLE
Sequential OCR task handling

### DIFF
--- a/src/static/script.js
+++ b/src/static/script.js
@@ -65,7 +65,7 @@ function setActionButtons(row, status, taskId) {
     const cell = row.querySelector('.action-cell');
     cell.innerHTML = '';
 
-    if (status === 'running') {
+    if (status === 'running' || status === 'waiting') {
         const cancelBtn = document.createElement('button');
         cancelBtn.className = 'btn btn-warning btn-sm cancel-btn';
         cancelBtn.innerText = '중지';
@@ -110,7 +110,7 @@ function updateTaskRow(task) {
     if (status === 'completed') {
         statusHtml = `<span class="download-subtitles" style="cursor:pointer; color: blue; text-decoration: underline;">${status}</span>`;
     } else {
-        statusHtml = status;
+        statusHtml = (status === 'waiting') ? '대기' : status;
         if (task.error) {
             statusHtml += `: ${task.error}`;
         }


### PR DESCRIPTION
## Summary
- add `Task` dataclass
- migrate task handling logic to use dataclass objects
- convert dataclass objects to dictionaries when sending updates or serving API
- remove dedicated pending and current task trackers
- infer next/active tasks directly from `tasks`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684693aec668832ab06c7262f2e0d463