### PR TITLE
Add running task check before vllm health polling

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -21,7 +21,8 @@ from fastapi.templating import Jinja2Templates
 import aiofiles
 import cv2
 
-from core.ocr import process_ocr, UPLOAD_DIR
+from core.ocr import process_ocr, UPLOAD_DIR, base_url
+import openai
 
 
 class Status(str, Enum):
@@ -136,6 +137,16 @@ templates = Jinja2Templates(directory="templates")
 @app.get("/", response_class=HTMLResponse)
 async def read_root(request: Request):
     return templates.TemplateResponse("index.html", {"request": request})
+
+@app.get("/vllm_health")
+async def vllm_health():
+    """Check if vllm server is reachable"""
+    client = openai.AsyncOpenAI(base_url=base_url, api_key="dummy_key")
+    try:
+        await client.models.list()
+        return {"status": "ok"}
+    except Exception:
+        return {"status": "down"}
 
 @app.post("/upload_video/")
 async def upload_video(file: UploadFile = File(...)):


### PR DESCRIPTION
## Summary
- skip periodic vllm health checks while OCR is running
- track task status in the client to know when a job is active

## Testing
- `python -m compileall -q src`


------
https://chatgpt.com/codex/tasks/task_e_686120a2a458832a816c8d6d99bda8ee