### PR TITLE
OCR 1프레임 고정

### DIFF
--- a/src/core/ocr.py
+++ b/src/core/ocr.py
@@ -59,9 +59,8 @@ def format_time(seconds):
 
 # 동영상 파일에서 프레임을 배치 단위로 생성하는 제너레이터.
 def frame_batch_generator(
-    cap: cv2.VideoCapture, 
-    x, y, width, height, 
-    frame_interval,
+    cap: cv2.VideoCapture,
+    x, y, width, height,
     end_frame: int = None
 ) -> Generator[List, None, None]:
     while True:
@@ -74,10 +73,6 @@ def frame_batch_generator(
             cap.release()
             break
         
-        # frame_interval 프레임 마다 OCR 수행
-        if frame_number % frame_interval != 0:
-            continue
-
         # 이미지 크롭
         cropped_frame = frame[y:y+height, x:x+width]
 
@@ -123,10 +118,9 @@ async def ocr_one_frame(
     return frame_number, ocr_text
     
 async def process_ocr(
-    video_filename, 
-    x, y, width, height, 
-    interval=0.3, 
-    start_time=0, 
+    video_filename,
+    x, y, width, height,
+    start_time=0,
     end_time=None
 ):
     # 파일 경로 정보 초기화
@@ -148,9 +142,6 @@ async def process_ocr(
     end_frame = int(cap.get(cv2.CAP_PROP_FRAME_COUNT)) if end_time is None else int(end_time * frame_rate) # OCR 종료 프레임
     total_frames = end_frame - start_frame # OCR 을 진행할 총 프레임 수
 
-    # interval 초마다 OCR 수행
-    frame_rate = cap.get(cv2.CAP_PROP_FPS)
-    frame_interval = max(1, int(round(frame_rate * interval)))  # 최소 1프레임
 
     # OCR 을 진행할 프레임으로 이동 
     start_ocr_frame = max(start_frame, last_frame_number)
@@ -177,7 +168,7 @@ async def process_ocr(
         #  실행 중·대기 중인 태스크 집합
         running: set[asyncio.Task] = set()
 
-        for frame_number, img_b64 in frame_batch_generator(cap, x, y, width, height, frame_interval, end_frame):
+        for frame_number, img_b64 in frame_batch_generator(cap, x, y, width, height, end_frame):
 
             # 새 태스크 추가
             task = asyncio.create_task(ocr_one_frame(client, frame_number, img_b64))
@@ -202,7 +193,7 @@ async def process_ocr(
                     "time": round(fn / frame_rate, 3),
                     "text": ocr_text,
                 })
-                next_frame_to_write += frame_interval     # 혹은 frame_interval 간격만큼 증가
+                next_frame_to_write += 1
                 percentage = round((fn - start_frame) / total_frames * 100, 2)
                 yield percentage
             csvfile.flush()

--- a/src/static/script.js
+++ b/src/static/script.js
@@ -13,7 +13,6 @@ const taskStatusMap = {};
 let boundingBox = document.getElementById('bounding-box');
 let handles = document.querySelectorAll('.handle');
 
-let intervalValue = 0.3;
 let dragging = false;
 let dragDirection = '';
 let startY = 0;
@@ -393,25 +392,6 @@ document.addEventListener('mouseup', function(e) {
     dragDirection = '';
 });
 
-// interval 설정
-const intervalInput = document.getElementById('intervalInput');
-intervalInput.addEventListener("input", (event) => {
-    intervalValue = parseFloat(event.target.value);
-});
-
-const frameBasedOCRCheckbox = document.getElementById('frameBasedOCR');
-frameBasedOCRCheckbox.addEventListener('change', function() {
-    if (this.checked) {
-        // 체크되면 입력 필드를 비활성화하고 intervalValue를 -1로 설정
-        intervalInput.disabled = true;
-        intervalValue = -1;
-    } else {
-        // 체크 해제 시 입력 필드 활성화 후 현재 값을 intervalValue로 사용
-        intervalInput.disabled = false;
-        intervalValue = parseFloat(intervalInput.value);
-    }
-});
-
 // mm:ss 형식의 문자열을 초 단위로 변환하는 함수 (예: "02:30" -> 150초)
 function parseTimeString(timeStr) {
     const parts = timeStr.split(':');
@@ -456,7 +436,6 @@ startOcrBtn.addEventListener('click', async function() {
     formData.append('y', y);
     formData.append('width', width);
     formData.append('height', height);
-    formData.append('interval_value', intervalValue);
     if (startTime != 0) {
         formData.append('start_time', startTime);
     }

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -56,16 +56,6 @@
                 </div>
             </div>
             <div class="row mt-4">
-                <div class="col-md-6">
-                    <label for="intervalInput">OCR 간격(초):</label>
-                    <input type="number" id="intervalInput" step="0.1" min="0.1" value="0.3">
-                    <div class="form-check mt-2">
-                        <input type="checkbox" class="form-check-input" id="frameBasedOCR">
-                        <label class="form-check-label" for="frameBasedOCR">1프레임 단위로 OCR 진행</label>
-                    </div>
-                </div>
-            </div>
-            <div class="row mt-4">
                 <div class="col-md-2">
                     <label for="startTimeInput">OCR 시작 시간 (초):</label>
                     <input type="text" id="startTimeInput" placeholder="mm:ss" value="00:00" class="form-control">


### PR DESCRIPTION
## 변경 사항
- OCR 수행 간격을 1프레임으로 고정
- 불필요해진 프레임 간격 관련 UI 요소 제거
- Task 구조체와 엔드포인트에서 interval 파라미터 삭제
- 남은 interval 필드를 로드 시 무시하도록 처리

## 테스트
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_687b462fb88c832a88413ff3598a92b3