### PR TITLE
파일명 칼럼 폭 제한으로 GUI 레이아웃 개선

### DIFF
--- a/src/static/style.css
+++ b/src/static/style.css
@@ -1,6 +1,16 @@
 /* 작업 목록 테이블 관련 스타일 */
 #task-list {
     margin-top: 20px;
+    table-layout: fixed;
+    width: 100%;
+}
+
+#task-list th:first-child,
+#task-list td.video-file {
+    width: 200px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .table td {


### PR DESCRIPTION
## 요약
- 작업 목록 테이블에서 파일명 칼럼의 폭을 제한하여 GUI가 뭉치는 문제 방지
- 긴 파일명을 말줄임(...) 처리

## 테스트
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68954e997ebc832a832a90d4141a732f